### PR TITLE
Fix Non RFC2822/ISO date formats

### DIFF
--- a/src/components/home/TicketOpen.vue
+++ b/src/components/home/TicketOpen.vue
@@ -18,7 +18,7 @@ import moment from "moment";
 export default {
   data() {
     const today = moment();
-    const dday = moment("2019-7-26");
+    const dday = moment("2019-07-26");
     const diffDays = dday.diff(today, "days") + 1;
     return {
       diffDays,


### PR DESCRIPTION
The date format is incorrect and is shown as D-NaN in some browsers (e.g. Safari).

Deprecation warning: value provided is not in a recognized RFC2822 or ISO format. moment construction falls back to js Date(), which is not reliable across all browsers and versions. Non RFC2822/ISO date formats are discouraged and will be removed in an upcoming major release. 