### PR TITLE
Add multi-page config to vue.config.js

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -16,4 +16,8 @@ module.exports = {
       },
     },
   },
+  pages: {
+    index: 'src/main.js',
+    timetable: 'src/main.js'
+  }
 };


### PR DESCRIPTION
I shared a direct link of TimeTable(https://milooy.github.io/DSTS2019/timetable), but the link is broken.

Adding a multi-page build configuration will also create a `timetable.html` file in the build results.
(reference : https://cli.vuejs.org/config/#pages)